### PR TITLE
Patchwork: adds revision number to PW email

### DIFF
--- a/patchwork/models.py
+++ b/patchwork/models.py
@@ -666,7 +666,7 @@ class SeriesRevision(models.Model):
         return name
 
     def __str__(self):
-        return "Revision " + str(self.version)
+        return "Revision: " + str(self.version)
 
 
 class SeriesRevisionPatch(models.Model):

--- a/patchwork/views/api.py
+++ b/patchwork/views/api.py
@@ -377,6 +377,7 @@ class ResultMixin(object):
         body = ''
         body += '== %s Details ==\n\n' % self._object_type(obj)
         body += 'Series: ' + obj.human_name() + '\n'
+        body += obj.__str__() + '\n'
         body += 'URL   : ' + \
                 request.build_absolute_uri(check_obj.get_absolute_url()) + '\n'
         body += 'State : ' + result.get_state_display() + '\n'


### PR DESCRIPTION
Revision number should be displayed on every email sent by Patchwork
so patch/patches can be easily detected and, if aplicable, corrected
by the owner. This patch adds the revision number to the body of
such email.

[YOCTO #10064]

Signed-off-by: Daniela Plascencia daniela.plascencia@intel.com
